### PR TITLE
Fixed html import (Old html package is invalid)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/hunterkepley/gosanitize
+
+go 1.18
+
+require golang.org/x/net v0.0.0-20220809012201-f428fae20770

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.0.0-20220809012201-f428fae20770 h1:dIi4qVdvjZEjiMDv7vhokAZNGnz3kepwuXqFKYDdDMs=
+golang.org/x/net v0.0.0-20220809012201-f428fae20770/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=

--- a/sanitize.go
+++ b/sanitize.go
@@ -42,7 +42,7 @@ package gosanitize
 
 import (
 	"bytes"
-	"code.google.com/p/go.net/html"
+	"golang.org/x/net/html"
 	"errors"
 	"io"
 	"net/url"


### PR DESCRIPTION
The old HTML package did not download as it is old and has been replaced by a newer package/link. I updated it to use the different link.